### PR TITLE
add gazebo path

### DIFF
--- a/cuboid_gazebo/launch/robot_office.launch
+++ b/cuboid_gazebo/launch/robot_office.launch
@@ -1,5 +1,6 @@
 <!-- -*- mode: XML -*- -->
 <launch>
+  <env name="GAZEBO_MODEL_PATH" value="$(find cuboid_gazebo)/models:$(optenv GAZEBO_MODEL_PATH)"/>
   <param name="/use_sim_time" value="true"/>
   <arg name="robot" default="cuboid"/>
   <arg name="gui" default="true"/>


### PR DESCRIPTION
gazeboのモデルの読み込みが遅い、もしくは来ない原因としてPathを引いていないためだったので追加。
[参考URL](https://qiita.com/srs/items/ac242e46177c2b797a7b#roslaunch%E4%B8%AD%E3%81%A7%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%82%92%E8%A8%AD%E5%AE%9A)